### PR TITLE
chore: qualify function call to avoid unused lint

### DIFF
--- a/mel/src/main.rs
+++ b/mel/src/main.rs
@@ -27,7 +27,7 @@ mod error;
 
 use error::MelError;
 use mel_libs::access_key::AccessKey;
-use mel_libs::crypt::{create_kek, dec, get_salt_hex, iv, AESParam};
+use mel_libs::crypt::{create_kek, dec, iv, AESParam};
 use mel_libs::token_map::TokenMap;
 use std::io;
 use std::path::Path;
@@ -131,7 +131,7 @@ fn decrypt_edek() -> Result<Dek, error::MelError> {
 
     debug_println!("MEL: I will decrypt your EDEK.");
 
-    debug_println!("MEL: MIMIR_SALT {}", get_salt_hex());
+    debug_println!("MEL: MIMIR_SALT {}", mel_libs::crypt::get_salt_hex());
 
     let tm = TokenMap::load(Path::new(TOKENS_TSV_PATH))
         .map_err(|_| error::MelError::MimirTokenMapUnreadable)?;


### PR DESCRIPTION
Fixes this lint, which only occurs in `--release` builds:

![image](https://github.com/user-attachments/assets/7dea7d41-7181-4329-88a4-677d5069eaaf)
