### PR TITLE
fix: RHOKP-13 Allow users to restart container

### DIFF
--- a/mel/src/main.rs
+++ b/mel/src/main.rs
@@ -191,7 +191,7 @@ fn decrypt_edek() -> Result<Dek, error::MelError> {
 
         clean_up();
     } else if Path::new(SOLR_PORTAL_PATH).exists() {
-        debug_println!("using solr index that was previously decrypted and unpacked");
+        debug_println!("using previously unpacked solr index");
     }
     else {
         return Err(error::MelError::SolrIndexNotFound);

--- a/mel/src/main.rs
+++ b/mel/src/main.rs
@@ -190,7 +190,10 @@ fn decrypt_edek() -> Result<Dek, error::MelError> {
         debug_println!("solr index unpacked");
 
         clean_up();
-    } else {
+    } else if Path::new(SOLR_PORTAL_PATH).exists() {
+        debug_println!("using solr index that was previously decrypted and unpacked");
+    }
+    else {
         return Err(error::MelError::SolrIndexNotFound);
     }
 


### PR DESCRIPTION
## Testing steps

### Verify user-reported bug: Cannot execute `mel` more than once in container

Checkout `mimir-cli`'s main branch and use the latest commit/submodule ref of MEL.

Do a `mimir-cli` ETL and build the podman image in the load step:

```
mimir e --sample-size 1 && mimir t && mimir l -fergszp
```

Run the container and get a BASH session:

```
podman run -p 8080:8080 -p 8443:8443 --env "ACCESS_KEY=<your access key>" -it localhost/mimir:latest bash                   
```

within the BASH session you get, execute `mel` and let it run for a bit to get to the point where SOLR is running. Press ctrl+C to end execution. Then execute `mel` again and you should see:

> ERR_009: Solr search index is missing. Please retrieve a new RHOKP image from registry.redhat.io, or contact Red Hat support.

### Verify the bug fix: Can execute `mel` many times in container

Update the ref of MEL (the git submodule) to this branch/commit/ref. You can do this by `cd`ing into the directory and `git fetch origin` and checking out this branch or by updating the git submodule if you'd like.

Do a `mimir-cli` ETL and build the podman image in the load step:

```
mimir e --sample-size 1 && mimir t && mimir l -fergszp
```

Run the container and get a BASH session:

```
podman run -p 8080:8080 -p 8443:8443 --env "ACCESS_KEY=<your access key>" -it localhost/mimir:latest bash                   
```

within the BASH session you get, execute `mel` and let it run for a bit to get to the point where SOLR is running. Press ctrl+C to end execution. Execute `mel` again, and you should see the exact same that you expect to see when you successfully execute `mel` except that the logs will inform you that port 8983 is already being used (by your last execution of `mel`):

```
bash-4.4$ mel
Thu May 22 17:32:58 UTC 2025: Starting Solr server
=> sourcing 10-set-mpm.sh ...
=> sourcing 20-copy-config.sh ...
=> sourcing 40-ssl-certs.sh ...

Port 8983 is already being used by another process (pid: 89)
Please choose a different port using the -p option.
```