### PR TITLE
RHOKP-238: Configure CI cargo audit

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,5 +18,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Check
       run: cargo check --verbose
+    - name: Audit
+      run: cargo audit
     - name: Run tests
       run: cargo test --verbose


### PR DESCRIPTION
Trying to get `cargo audit` setup for MEL with Github Actions.