### PR TITLE
chore: mitigate RUSTSEC-2026-0067

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/mel/Cargo.toml
+++ b/mel/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 mel_libs = { path = "../mel_libs/" }
-tar = "0.4.41"
+tar = "0.4.45"
 flate2 = "1.0.33"
 
 [build-dependencies]


### PR DESCRIPTION
Updates tar to 0.4.45